### PR TITLE
Make event list more compact & table-like

### DIFF
--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -22,7 +22,7 @@
                   {% if postyear > nowyear or postday >= nowday and postyear >= nowyear %}
                     {% assign isEvent = 1 %}
                     <li>
-                      <a class='eventTitle' href="{{ post.link }}">{{ post.title }}, {{ post.date | date: "%-d %B %Y"}}</a> 
+                      {{ post.date | date: "%-d %B %Y"}} -- <a class='eventTitle' href="{{ post.link }}">{{ post.title }}</a> 
                       <div class='eventSub'>{{ post.text }}</div>
                     </li>
                   {% endif %}
@@ -63,7 +63,7 @@
                           {% assign nowday = nowday | minus: 2 %}
                           {% if postyear < nowyear or postday < nowday and postyear == nowyear %}
                             <li>
-                              <a class='eventTitle' href="{{ post.link }}">{{ post.title }}, {{ post.date | date: "%-d %B %Y"}}</a>
+                              {{ post.date | date: "%-d %B %Y"}} -- <a class='eventTitle' href="{{ post.link }}">{{ post.title }}</a> 
                               <div class='eventSub'>{{ post.text }}</div>
                             </li>
                           {% endif %}

--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -22,7 +22,7 @@
                   {% if postyear > nowyear or postday >= nowday and postyear >= nowyear %}
                     {% assign isEvent = 1 %}
                     <li>
-                      {{ post.date | date: "%-d %B %Y"}} -- <a class='eventTitle' href="{{ post.link }}">{{ post.title }}</a> 
+                      {{ post.date | date: "%-d %B %Y"}} -- <a class='eventTitle' href="{{ post.link }}">{{ post.title }}</a>
                       <div class='eventSub'>{{ post.text }}</div>
                     </li>
                   {% endif %}
@@ -63,7 +63,7 @@
                           {% assign nowday = nowday | minus: 2 %}
                           {% if postyear < nowyear or postday < nowday and postyear == nowyear %}
                             <li>
-                              {{ post.date | date: "%-d %B %Y"}} -- <a class='eventTitle' href="{{ post.link }}">{{ post.title }}</a> 
+                              {{ post.date | date: "%-d %B %Y"}} -- <a class='eventTitle' href="{{ post.link }}">{{ post.title }}</a>
                               <div class='eventSub'>{{ post.text }}</div>
                             </li>
                           {% endif %}


### PR DESCRIPTION
This should ensure that the date is always in front and forms a column-like shape when there are many events. Only the differently long months will break this, not the differently long event titles.

Like this:

```

10 October 2018 -- First steps into R, 
17 October 2018 -- First steps into Python
24 October 2018 -- Coworking
...
21 November 2018 -- Regular expressions. What are those? What are they useful for?
```